### PR TITLE
Add notices page

### DIFF
--- a/app/routes/notices.md
+++ b/app/routes/notices.md
@@ -1,6 +1,0 @@
----
-meta:
-  title: GCN - Notices
----
-
-# GCN Notices

--- a/app/routes/notices.tsx
+++ b/app/routes/notices.tsx
@@ -1,0 +1,411 @@
+import {
+  Button,
+  CardBody,
+  CardFooter,
+  CardGroup,
+  CardHeader,
+  IconClose,
+  Tag,
+} from '@trussworks/react-uswds'
+import { ReactNode, useEffect, useRef, useState } from 'react'
+import ReactTags, {
+  SuggestionComponentProps,
+  Tag as ReactTag,
+  TagComponentProps,
+} from 'react-tag-autocomplete'
+import { MetaFunction } from 'remix'
+
+export const meta: MetaFunction = () => ({
+  title: 'GCN - Notices',
+})
+
+function NoticeCard({
+  children,
+  name,
+  tags,
+  selectedTags,
+  href,
+}: {
+  children: ReactNode
+  name: string
+  tags: string[]
+  selectedTags: string[]
+  href: string
+}) {
+  const tagSet = new Set(tags)
+  return selectedTags.length == 0 ||
+    selectedTags.every((tag) => tagSet.has(tag)) ? (
+    <a
+      href={href}
+      className="tablet:grid-col-4 usa-card notice-card"
+      data-testid="Card"
+    >
+      <div className="usa-card__container">
+        <CardHeader>
+          <h3>{name}</h3>
+        </CardHeader>
+        <CardBody>{children}</CardBody>
+        <CardFooter>
+          {tags?.map((tag) => (
+            <Tag key={tag}>{tag}</Tag>
+          ))}
+        </CardFooter>
+      </div>
+    </a>
+  ) : null
+}
+
+function ReactTagComponent({
+  tag,
+  removeButtonText,
+  onDelete,
+}: TagComponentProps) {
+  return (
+    <Tag>
+      {tag.name}{' '}
+      <Button
+        type="button"
+        unstyled
+        title={removeButtonText}
+        onClick={onDelete}
+      >
+        <IconClose className="margin-left-1 text-bottom" color={'white'} />
+      </Button>
+    </Tag>
+  )
+}
+
+function ReactSuggestionComponent({ item }: SuggestionComponentProps) {
+  return <Tag>{item.name}</Tag>
+}
+
+export default function Notices() {
+  const ref = useRef<ReactTags>(null)
+  const [tags, setTags] = useState<ReactTag[]>([])
+  const suggestions = ['gw', 'gamma', 'nu', 'x-ray', 'uv', 'optical']
+  const tagNames = tags.map((tag) => tag.name)
+
+  /// @ts-expect-error: focusInput method is present, but not documented in
+  // module definition from @types/react-tag-autocomplete
+  useEffect(() => ref.current?.focusInput())
+
+  return (
+    <>
+      <h1>GCN Notices</h1>
+      <p>
+        GCN Notices are real-time, machine-readable alerts that are submitted by
+        participating facilities and redistributed publicly.
+      </p>
+      <div className="margin-bottom-2">
+        <ReactTags
+          onAddition={(tag) => setTags((prevTags) => [...prevTags, tag])}
+          onDelete={(i) =>
+            setTags((prevTags) => {
+              const newTags = prevTags.slice(0)
+              newTags.splice(i, 1)
+              return newTags
+            })
+          }
+          suggestions={suggestions.map((name) => ({ name, id: name }))}
+          tags={tags}
+          tagComponent={ReactTagComponent}
+          suggestionComponent={ReactSuggestionComponent}
+          autoresize={false}
+          minQueryLength={1}
+          ref={ref}
+          placeholderText="Filter by tag"
+          delimiters={['Enter', 'Tab', ' ', ',']}
+        />
+      </div>
+      <CardGroup>
+        <NoticeCard
+          name="LIGO/Virgo/KAGRA"
+          href="https://gcn.gsfc.nasa.gov/lvc_events.html"
+          tags={['gw']}
+          selectedTags={tagNames}
+        >
+          Gravitational-wave transients detected by the LIGO, Virgo, and KAGRA
+          network.
+        </NoticeCard>
+        <NoticeCard
+          name="IceCube"
+          href="https://gcn.gsfc.nasa.gov/amon_icecube_gold_bronze_events.html"
+          tags={['nu']}
+          selectedTags={tagNames}
+        >
+          High-energy astrophysical neutrino event candidates detected by
+          IceCube, aggregated by AMON.
+        </NoticeCard>
+        <NoticeCard
+          name="HAWC"
+          href="https://gcn.gsfc.nasa.gov/amon_hawc_events.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          High-energy gamma rays detected by HAWC, aggregated by AMON.
+        </NoticeCard>
+        <NoticeCard
+          name="IceCube–HAWC Coincidences"
+          href="https://gcn.gsfc.nasa.gov/amon_nu_em_coinc_events.html"
+          tags={['gamma', 'nu']}
+          selectedTags={tagNames}
+        >
+          Coincidences between IceCube neutrino and HAWC gamma-ray events,
+          aggregated by AMON.
+        </NoticeCard>
+        <NoticeCard
+          name="IceCube Cascades"
+          href="https://gcn.gsfc.nasa.gov/amon_icecube_cascade_events.html"
+          tags={['nu']}
+          selectedTags={tagNames}
+        >
+          High-energy cascades detected by IceCube, aggregated by AMON.
+        </NoticeCard>
+        <NoticeCard
+          name="CALET"
+          href="https://gcn.gsfc.nasa.gov/calet_triggers.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          Gamma-ray transients detected by the GBM instrument on CALET.
+        </NoticeCard>
+        <NoticeCard
+          name="MAXI"
+          href="https://gcn.gsfc.nasa.gov/maxi_grbs.html"
+          tags={['x-ray']}
+          selectedTags={tagNames}
+        >
+          X-ray transients detected by the MAXI instrument on the ISS.
+        </NoticeCard>
+        <NoticeCard
+          name="Fermi GBM"
+          href="https://gcn.gsfc.nasa.gov/fermi_grbs.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by the GBM instrument on Fermi.
+        </NoticeCard>
+        <NoticeCard
+          name="Fermi LAT"
+          href="https://gcn.gsfc.nasa.gov/fermi_lat_mon_trans.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          Non-GRB gamma-ray transients detected by the LAT instrument on Fermi.
+        </NoticeCard>
+        <NoticeCard
+          name="Swift GRBs"
+          href="https://gcn.gsfc.nasa.gov/swift_grbs.html"
+          tags={['gamma', 'x-ray', 'uv', 'optical']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by Swift.
+        </NoticeCard>
+        <NoticeCard
+          name="Swift Sub-Threshold"
+          href="https://gcn.gsfc.nasa.gov/swift_sub_sub_archive.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          Sub-threshold events detected by Swift.
+        </NoticeCard>
+        <NoticeCard
+          name="Swift BAT Monitor"
+          href="https://gcn.gsfc.nasa.gov/bat_mon_alerts.html"
+          tags={['gamma', 'x-ray']}
+          selectedTags={tagNames}
+        >
+          Monitoring of known sources by the BAT instrument on Swift.
+        </NoticeCard>
+        <NoticeCard
+          name="Swift Counterpart"
+          href="https://gcn.gsfc.nasa.gov/counterpart_tbl.html"
+          tags={['x-ray', 'gw']}
+          selectedTags={tagNames}
+        >
+          Swift XRT counterpart candidates of LVK events.
+        </NoticeCard>
+        <NoticeCard
+          name="INTEGRAL GRBs"
+          href="https://gcn.gsfc.nasa.gov/integral_grbs.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by INTEGRAL.
+        </NoticeCard>
+        <NoticeCard
+          name="INTEGRAL SPI-ACS"
+          href="https://gcn.gsfc.nasa.gov/integral_spiacs.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          Gamma-ray transients and light curves from the SPI-ACS instrument on
+          INTEGRAL.
+        </NoticeCard>
+        <NoticeCard
+          name="AGILE"
+          href="https://gcn.gsfc.nasa.gov/agile_grbs.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by AGILE.
+        </NoticeCard>
+        <NoticeCard
+          name="IPN"
+          href="https://gcn.gsfc.nasa.gov/ipn/gcn_ipn_raw.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          Light curves of GRBs detected by instruments that participate in the
+          InterPlanetary Network (IPN).
+        </NoticeCard>
+        <NoticeCard
+          name="Konus/WIND"
+          href="https://gcn.gsfc.nasa.gov/konus_grbs.html"
+          tags={['gamma']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by Konus/WIND.
+        </NoticeCard>
+        <NoticeCard
+          name="MOA"
+          href="https://gcn.gsfc.nasa.gov/moa_events.html"
+          tags={['optical']}
+          selectedTags={tagNames}
+        >
+          Gravitational microlensing events detected by MOA.
+        </NoticeCard>
+        <NoticeCard
+          name="SNEWS"
+          href="https://gcn.gsfc.nasa.gov/snews_trans.html"
+          tags={['nu']}
+          selectedTags={tagNames}
+        >
+          Supernova neutrinos reported by the SuperNova Early Warning System
+          (SNEWS).
+        </NoticeCard>
+        <NoticeCard
+          name="Super-Kamiokande"
+          href="https://gcn.gsfc.nasa.gov/sk_sn_events.html"
+          tags={['nu']}
+          selectedTags={tagNames}
+        >
+          Supernova neutrinos detected by Super-Kamiokande.
+        </NoticeCard>
+        <NoticeCard
+          name="IPN GRB Positions"
+          href="https://gcn.gsfc.nasa.gov/ipn/gcn_ipn_pos.html"
+          tags={['gamma', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          Position estimates of GRBs from IPN.
+        </NoticeCard>
+        <NoticeCard
+          name="IPN Segments"
+          href="https://gcn.gsfc.nasa.gov/ipn/gcn_ipn.html"
+          tags={['gamma', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          Light curves of GRBs from IPN.
+        </NoticeCard>
+        <NoticeCard
+          name="IceCube HESE"
+          href="https://gcn.gsfc.nasa.gov/amon_hese_events.html"
+          tags={['nu', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          IceCube high-energy starting events (HESE).
+        </NoticeCard>
+        <NoticeCard
+          name="IceCube EHE"
+          href="https://gcn.gsfc.nasa.gov/amon_hese_events.html"
+          tags={['nu', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          IceCube extremely high energy (EHE) events.
+        </NoticeCard>
+        <NoticeCard
+          name="Suzaku"
+          href="https://gcn.gsfc.nasa.gov/suzaku_wam.html"
+          tags={['x-ray', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          X-ray transients detected by the Wide-band All-sky Monitor (WAM) on
+          Suzaku.
+        </NoticeCard>
+        <NoticeCard
+          name="RXTE"
+          href="https://gcn.gsfc.nasa.gov/rxte_grbs.html"
+          tags={['gamma', 'x-ray', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by RXTE.
+        </NoticeCard>
+        <NoticeCard
+          name="HETE-2"
+          href="https://gcn.gsfc.nasa.gov/hete_grbs.html"
+          tags={['gamma', 'x-ray', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by HETE-2.
+        </NoticeCard>
+        <NoticeCard
+          name="MILAGRO"
+          href="https://gcn.gsfc.nasa.gov/milagro_trans.html"
+          tags={['gamma', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by MILAGRO.
+        </NoticeCard>
+        <NoticeCard
+          name="BeppoSAX"
+          href="https://gcn.gsfc.nasa.gov/sax_grbs.html"
+          tags={['x-ray', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          X-ray observations of GRBs by BeppoSAX.
+        </NoticeCard>
+        <NoticeCard
+          name="NEAR"
+          href="https://gcn.gsfc.nasa.gov/near_grbs.html"
+          tags={['gamma', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          GRBs and gamma-ray transients detected by NEAR.
+        </NoticeCard>
+        <NoticeCard
+          name="ALEXIS"
+          href="https://gcn.gsfc.nasa.gov/alexis_trans.html"
+          tags={['uv', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          Extreme UV transients detected by ALEXIS.
+        </NoticeCard>
+        <NoticeCard
+          name="Compton BATSE GRBs"
+          href="https://gcn.gsfc.nasa.gov/batse_grbs.html"
+          tags={['gamma', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by BATSE on CGRO.
+        </NoticeCard>
+        <NoticeCard
+          name="Compton COMPTEL GRBs"
+          href="https://gcn.gsfc.nasa.gov/comptel_grbs.html"
+          tags={['gamma', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          GRBs detected by COMPTEL on CGRO.
+        </NoticeCard>
+        <NoticeCard
+          name="Compton Status"
+          href="https://gcn.gsfc.nasa.gov/gro/gcn_gro.html"
+          tags={['gamma', 'discontinued']}
+          selectedTags={tagNames}
+        >
+          Status of the CGRO spacecraft.
+        </NoticeCard>
+      </CardGroup>
+    </>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^17.0.2",
         "react-copy-to-clipboard": "^5.0.4",
         "react-dom": "^17.0.2",
+        "react-tag-autocomplete": "^6.3.0",
         "react-topbar-progress-indicator": "^4.1.1",
         "remark-gfm": "^3.0.1",
         "remix": "^1.2.1"
@@ -35,6 +36,7 @@
         "@types/react": "^17.0.24",
         "@types/react-copy-to-clipboard": "^5.0.2",
         "@types/react-dom": "^17.0.9",
+        "@types/react-tag-autocomplete": "^6.1.1",
         "@typescript-eslint/eslint-plugin": "^5.10.0",
         "@typescript-eslint/parser": "^5.10.0",
         "autoprefixer": "^10.4.2",
@@ -2405,6 +2407,15 @@
       "version": "17.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-tag-autocomplete": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/react-tag-autocomplete/-/react-tag-autocomplete-6.1.1.tgz",
+      "integrity": "sha512-/mVNQUHXtKGihHBP/q0znL/CHbtrZL82t8ch/msQCkywqDkoZeE7QzhyLTG535Y/estsI6EcJi8Jd5HersPHuw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -13471,6 +13482,19 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-tag-autocomplete": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-tag-autocomplete/-/react-tag-autocomplete-6.3.0.tgz",
+      "integrity": "sha512-MUBVUFh5eOqshUm5NM20qp7zXk8TzSiKO4GoktlFzBLIOLs356npaMKtL02bm0nFV2f1zInUrXn1fq6+i5YX0w==",
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.5.0",
+        "react": "^16.5.0 || ^17.0.0",
+        "react-dom": "^16.5.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-topbar-progress-indicator": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/react-topbar-progress-indicator/-/react-topbar-progress-indicator-4.1.1.tgz",
@@ -19911,6 +19935,15 @@
       "version": "17.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-tag-autocomplete": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/react-tag-autocomplete/-/react-tag-autocomplete-6.1.1.tgz",
+      "integrity": "sha512-/mVNQUHXtKGihHBP/q0znL/CHbtrZL82t8ch/msQCkywqDkoZeE7QzhyLTG535Y/estsI6EcJi8Jd5HersPHuw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -28140,6 +28173,12 @@
         "history": "^5.2.0",
         "react-router": "6.2.2"
       }
+    },
+    "react-tag-autocomplete": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-tag-autocomplete/-/react-tag-autocomplete-6.3.0.tgz",
+      "integrity": "sha512-MUBVUFh5eOqshUm5NM20qp7zXk8TzSiKO4GoktlFzBLIOLs356npaMKtL02bm0nFV2f1zInUrXn1fq6+i5YX0w==",
+      "requires": {}
     },
     "react-topbar-progress-indicator": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^17.0.2",
     "react-copy-to-clipboard": "^5.0.4",
     "react-dom": "^17.0.2",
+    "react-tag-autocomplete": "^6.3.0",
     "react-topbar-progress-indicator": "^4.1.1",
     "remark-gfm": "^3.0.1",
     "remix": "^1.2.1"
@@ -51,6 +52,7 @@
     "@types/react": "^17.0.24",
     "@types/react-copy-to-clipboard": "^5.0.2",
     "@types/react-dom": "^17.0.9",
+    "@types/react-tag-autocomplete": "^6.1.1",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
     "autoprefixer": "^10.4.2",

--- a/theme/custom.scss
+++ b/theme/custom.scss
@@ -123,3 +123,154 @@ a[rel~='external'] {
 .contact-link a:visited {
   @include u-text($theme-link-color);
 }
+
+/*
+ * Styles for notice cards
+ */
+
+.notice-card:hover .usa-card__container {
+  @include u-border('ink');
+}
+
+.notice-card {
+  text-decoration: none;
+}
+
+/*
+ * react-tag-autocomplete styles, adapted from
+ * https://github.com/i-like-robots/react-tags/blob/main/example/styles.css
+ */
+
+.react-tags {
+  position: relative;
+  padding: 6px 0 0 6px;
+  border: 1px solid #d1d1d1;
+  border-radius: 1px;
+
+  /* shared font styles */
+  font-size: 1em;
+  line-height: 1.2;
+
+  /* clicking anywhere will focus the input */
+  cursor: text;
+}
+
+.react-tags.is-focused {
+  @include focus-outline;
+}
+
+.react-tags__selected {
+  display: inline;
+}
+
+.react-tags__selected-tag {
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0 6px 6px 0;
+  padding: 6px 8px;
+  border: 1px solid #d1d1d1;
+  border-radius: 2px;
+  background: #f1f1f1;
+
+  /* match the font styles */
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.react-tags__selected-tag:after {
+  content: '\2715';
+  color: #aaa;
+  margin-left: 8px;
+}
+
+.react-tags__selected-tag:hover,
+.react-tags__selected-tag:focus {
+  border-color: #b1b1b1;
+}
+
+.react-tags__search {
+  display: inline-block;
+
+  /* match tag layout */
+  padding: 7px 2px;
+  margin-bottom: 6px;
+
+  /* prevent autoresize overflowing the container */
+  max-width: 100%;
+}
+
+@media screen and (min-width: 30em) {
+  .react-tags__search {
+    /* this will become the offsetParent for suggestions */
+    position: relative;
+  }
+}
+
+.react-tags__search-input,
+input.react-tags__search-input:focus {
+  /* prevent autoresize overflowing the container */
+  max-width: 100%;
+
+  /* remove styles and layout from this element */
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: none;
+
+  /* match the font styles */
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.react-tags__search-input::-ms-clear {
+  display: none;
+}
+
+.react-tags__suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  z-index: z-index(100);
+}
+
+@media screen and (min-width: 30em) {
+  .react-tags__suggestions {
+    width: 240px;
+  }
+}
+
+.react-tags__suggestions ul {
+  margin: 4px -1px;
+  padding: 0;
+  list-style: none;
+  background: white;
+  border: 1px solid #d1d1d1;
+  border-radius: 2px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.react-tags__suggestions li {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 8px;
+}
+
+.react-tags__suggestions li mark {
+  text-decoration: underline;
+  background: none;
+  font-weight: 600;
+}
+
+.react-tags__suggestions li:hover {
+  cursor: pointer;
+  background: #eee;
+}
+
+.react-tags__suggestions li.is-active {
+  background: #b7cfe0;
+}
+
+.react-tags__suggestions li.is-disabled {
+  opacity: 0.5;
+  cursor: auto;
+}


### PR DESCRIPTION
Add a Notices page with links to the GCN Classic notice archives. You can filter the archive using an auto-completing search box.

https://user-images.githubusercontent.com/728407/158174801-f04405ab-c72e-433a-a686-3beff8b5a4fb.mov

