### PR TITLE
Use enum names for Swift notice types

### DIFF
--- a/app/routes/missions/swift.md
+++ b/app/routes/missions/swift.md
@@ -33,31 +33,31 @@ https://swift.gsfc.nasa.gov/archive/
 | Type | Typical Latency Since Burst | Location Precision | Description |
 | - | - | - | - |
 |**Flight Generated:** | | | |
-|BAT_Alert |~7 s | N/A | First Notice, Timestamp Alert|
-|BAT_QL_Pos |13–30 s | 1–3′ | QuickLook Position Notice (subset of BAT_POS info)|
-|BAT_Pos |13–30 s | 1–3′ | First Position Notice, the BAT Position|
-|BAT_PosNack |30–60 s | N/A | Only if no position was found|
-|BAT_SubThresh |13–30 s | 1–4′ | Sub-threshold triggers (Position)|
-|BAT_LC |~220 s | 1–3′ | Lightcurve (also has the position)|
-|FOM_Obs |14–41 s | 1–3′ | FOM decision: Observe or Not|
-|SC_Slew |14–41 s | 1–3′ | Spacecraft decision: Slew or Not|
-|XRT_Pos |30–80 s | &lt;7″ | XRT afterglow location|
-|XRT_PosNack |30–80 s | N/A | Could not find an XRT afterglow location|
-|XRT_Image |31–81 s | &lt;7″ | 2′×2′ FOV (5-30 s integration)|
-|XRT_Spectrum |40–81 s | N/A | Spectrum (few-to-100 s integration)|
-|XRT_Lightcurve |141–910 s | N/A | The x-ray lightcurve (106–826 s)|
-|UVOT_SrcList |~260 s | N/A | Thresholded pixel clusters|
-|UVOT_Image |~320 s | N/A | All pixels from an 80×80 pixel subarray|
-|UVOT_Pos |1–3 h | &lt;2″ | UVOT afterglow location (Gnd-generated only)|
-|UVOT_PosNack |1–3 h | N/A | Could not find an UVOT afterglow location|
+| `SWIFT_BAT_GRB_ALERT` |~7 s | N/A | First Notice, Timestamp Alert|
+| `SWIFT_BAT_QL_POS` |13–30 s | 1–3′ | QuickLook Position Notice (subset of BAT_POS info)|
+| `SWIFT_BAT_GRB_POS_ACK` |13–30 s | 1–3′ | First Position Notice, the BAT Position|
+| `SWIFT_BAT_GRB_POS_NACK` |30–60 s | N/A | Only if no position was found|
+| `SWIFT_BAT_SUB_THRESHOLD` |13–30 s | 1–4′ | Sub-threshold triggers (Position)|
+| `SWIFT_BAT_GRB_LC` |~220 s | 1–3′ | Lightcurve (also has the position)|
+| `SWIFT_FOM_OBS` |14–41 s | 1–3′ | FOM decision: Observe or Not|
+| `SWIFT_SC_SLEW` |14–41 s | 1–3′ | Spacecraft decision: Slew or Not|
+| `SWIFT_XRT_POSITION` |30–80 s | &lt;7″ | XRT afterglow location|
+| `SWIFT_XRT_POS_NACK` |30–80 s | N/A | Could not find an XRT afterglow location|
+| `SWIFT_XRT_IMAGE` |31–81 s | &lt;7″ | 2′×2′ FOV (5-30 s integration)|
+| `SWIFT_XRT_SPECTRUM` |40–81 s | N/A | Spectrum (few-to-100 s integration)|
+| `SWIFT_XRT_LC` |141–910 s | N/A | The x-ray lightcurve (106–826 s)|
+| `SWIFT_UVOT_FCHART` |~260 s | N/A | Thresholded pixel clusters|
+| `SWIFT_UVOT_DBURST` |~320 s | N/A | All pixels from an 80×80 pixel subarray|
+| `SWIFT_UVOT_POS` |1–3 h | &lt;2″ | UVOT afterglow location (Gnd-generated only)|
+| `SWIFT_UVOT_POS_NACK` |1–3 h | N/A | Could not find an UVOT afterglow location|
 |**Ground Processed:**| | | |
-|BAT_LC |~225 s | 1–3′ | Lightcurve (also has the position)|
-|XRT_Image |40–70 s | &lt;6″ | 2′×2′ FOV (~10 s integration)|
-|XRT_Spectrum |50–90 s | N/A | The spectrum from that integration (~10 s)|
-|UVOT_SrcList |~280 s | N/A | Thresholded pixel clusters|
-|UVOT_Image |~340 s | N/A | All pixels from an 80×80 pixel subarray|
+| `SWIFT_BAT_GRB_LC_PROC` |~225 s | 1–3′ | Lightcurve (also has the position)|
+| `SWIFT_XRT_IMAGE_PROC` |40–70 s | &lt;6″ | 2′×2′ FOV (~10 s integration)|
+| `SWIFT_XRT_SPECTRUM_PROC` |50–90 s | N/A | The spectrum from that integration (~10 s)|
+| `SWIFT_UVOT_FCHART_PROC` |~280 s | N/A | Thresholded pixel clusters|
+| `SWIFT_UVOT_DBURST_PROC` |~340 s | N/A | All pixels from an 80×80 pixel subarray|
 |**Special:**| | | |
-|BAT_Slew_Pos |1–6 h | 1–7′ | Bursts & Transient found in the slew data (BATSS)|
-|BAT_Monitor |1–12 h | 1–7′ | Flares from known sources|
-|BAT_SUB_SUB |1–12 h | 1–7′ | Sub-Sub-Threshold blips in all image produced on-board|
-|BAT_KNOWN |1–12 h | 1–7′ | Peaks of known-sources found in all image produced on-board|
+| `SWIFT_BAT_SLEW_POS` |1–6 h | 1–7′ | Bursts & Transient found in the slew data (BATSS)|
+| `SWIFT_BAT_MONITOR` |1–12 h | 1–7′ | Flares from known sources|
+| `SWIFT_BAT_SUBSUB` |1–12 h | 1–7′ | Sub-Sub-Threshold blips in all image produced on-board|
+| `SWIFT_BAT_KNOWN_SRC` |1–12 h | 1–7′ | Peaks of known-sources found in all image produced on-board|


### PR DESCRIPTION
Fixes #68.