### PR TITLE
Change SWIFT_XRT_POS_NACK to SWIFT_XRT_CENTROID

### DIFF
--- a/app/routes/missions/swift.md
+++ b/app/routes/missions/swift.md
@@ -42,7 +42,7 @@ https://swift.gsfc.nasa.gov/archive/
 | `SWIFT_FOM_OBS` |14–41 s | 1–3′ | FOM decision: Observe or Not|
 | `SWIFT_SC_SLEW` |14–41 s | 1–3′ | Spacecraft decision: Slew or Not|
 | `SWIFT_XRT_POSITION` |30–80 s | &lt;7″ | XRT afterglow location|
-| `SWIFT_XRT_POS_NACK` |30–80 s | N/A | Could not find an XRT afterglow location|
+| `SWIFT_XRT_CENTROID` |30–80 s | N/A | Could not find an XRT afterglow location|
 | `SWIFT_XRT_IMAGE` |31–81 s | &lt;7″ | 2′×2′ FOV (5-30 s integration)|
 | `SWIFT_XRT_SPECTRUM` |40–81 s | N/A | Spectrum (few-to-100 s integration)|
 | `SWIFT_XRT_LC` |141–910 s | N/A | The x-ray lightcurve (106–826 s)|


### PR DESCRIPTION
Scott has informed me by email that this was the correct name:

> Leo,
>
> Yes, it would make for a clearer/better name. I had suggested
> changing the name. But they wanted the name to stay because it
> matches usage/referencing within documents. So the usage continues
> in the original preload usage, to after launch usage, to any
> activity using the Swifts data names, and to stuff in the future.
>
> I understand. To your eyes and use, the POS_NACK looks better; the
> continuity of names. But to starting out before your time, that
> may well develop problem in the future.
>
> --scott