### PR TITLE
Remove workaround for remix-run/remix#1828

### DIFF
--- a/app/routes/api/client_credentials/$client_id.ts
+++ b/app/routes/api/client_credentials/$client_id.ts
@@ -17,8 +17,3 @@ export const action: ActionFunction = async ({ params, request }) => {
   await machine.deleteClientCredential(params.client_id)
   return null
 }
-
-// FIXME: workaround for https://github.com/remix-run/remix/issues/1828.
-// Resource routes (without browser code) don't get server pruning done.
-// Once fixed upstream, remove.
-export const meta = () => ({})

--- a/app/routes/api/client_credentials/index.ts
+++ b/app/routes/api/client_credentials/index.ts
@@ -23,8 +23,3 @@ export const action: ActionFunction = async ({ request }) => {
   ])
   return await machine.createClientCredential(body.name, body.scope)
 }
-
-// FIXME: workaround for https://github.com/remix-run/remix/issues/1828.
-// Resource routes (without browser code) don't get server pruning done.
-// Once fixed upstream, remove.
-export const meta = () => ({})

--- a/app/routes/auth.ts
+++ b/app/routes/auth.ts
@@ -9,8 +9,3 @@
 import type { LoaderFunction } from '@remix-run/node'
 import { authorize } from '~/lib/auth.server'
 export const loader: LoaderFunction = ({ request }) => authorize(request)
-
-// FIXME: workaround for https://github.com/remix-run/remix/issues/1828.
-// Resource routes (without browser code) don't get server pruning done.
-// Once fixed upstream, remove.
-export const meta = () => ({})

--- a/app/routes/login.ts
+++ b/app/routes/login.ts
@@ -9,8 +9,3 @@
 import type { LoaderFunction } from '@remix-run/node'
 import { login } from '~/lib/auth.server'
 export const loader: LoaderFunction = ({ request }) => login(request)
-
-// FIXME: workaround for https://github.com/remix-run/remix/issues/1828.
-// Resource routes (without browser code) don't get server pruning done.
-// Once fixed upstream, remove.
-export const meta = () => ({})

--- a/app/routes/logout.ts
+++ b/app/routes/logout.ts
@@ -9,8 +9,3 @@
 import type { LoaderFunction } from '@remix-run/node'
 import { logout } from '~/lib/auth.server'
 export const loader: LoaderFunction = ({ request }) => logout(request)
-
-// FIXME: workaround for https://github.com/remix-run/remix/issues/1828.
-// Resource routes (without browser code) don't get server pruning done.
-// Once fixed upstream, remove.
-export const meta = () => ({})


### PR DESCRIPTION
Seems to have been fixed upstream.