### PR TITLE
Do not refer to mission menu as on the "left"

### DIFF
--- a/app/routes/missions/index.md
+++ b/app/routes/missions/index.md
@@ -5,4 +5,4 @@ meta:
 
 # Missions, Instruments, and Facilities
 
-Observatories that generate GCN notices for transient alerts, as consumed by the science community. Explore mission resources and GCN notice details in left menu.
+Observatories that generate GCN notices for transient alerts, as consumed by the science community. Explore mission resources and GCN notice details in the menu.


### PR DESCRIPTION
Because this is a responsive layout, on mobile devices, the menu will be above the content, not to the left.

Also, we should avoid descriptions like "left", "right", "top", or "bottom" that might not make sense on screen reader devices.