### PR TITLE
Use slim size for dev banner

### DIFF
--- a/app/components/DevBanner.tsx
+++ b/app/components/DevBanner.tsx
@@ -31,8 +31,8 @@ export function DevBanner({ hostname }: { hostname: string }) {
   }
 
   return (
-    <SiteAlert variant="emergency" heading={heading}>
-      You are viewing {description} of GCN.
+    <SiteAlert slim variant="emergency">
+      <strong>{heading}.</strong> You are viewing {description} of GCN.
     </SiteAlert>
   )
 }


### PR DESCRIPTION
The full-size site alert was too distracting.

## Before
![Screen Shot 2022-06-22 at 13 12 45](https://user-images.githubusercontent.com/728407/175097819-6dc5d1d2-c9f6-4c50-b227-fcedef488dfc.png)

## After
![Screen Shot 2022-06-22 at 13 12 57](https://user-images.githubusercontent.com/728407/175097832-ec4dd2de-65ad-48a4-ac4f-1b5f7be99d47.png)
 