### PR TITLE
Add hero to landing page

### DIFF
--- a/app/routes/docs/index.md
+++ b/app/routes/docs/index.md
@@ -3,13 +3,16 @@ meta:
   title: GCN - About
 ---
 
-# About GCN
+# What is GCN?
 
-The General Coordinates Network (GCN) is a public collaboration platform run by NASA for the astronomy research community to share alerts and rapid communications about high-energy, multimessenger, and transient phenomena.
+The General Coordinates Network (GCN) is a public collaboration platform run by NASA for the astronomy research community to share alerts and rapid communications about high-energy, multimessenger, and transient phenomena. GCN is the established platform for publishing discoveries and follow-up of gamma-ray bursts (GRBs), gravitational-wave (GW) compact binary mergers, and high-energy neutrinos. GCN distributes alerts between space- and ground-based observatories, physics experiments, and thousands of astronomers around the world.
 
-GCN is the established platform for publishing discoveries and follow-up of gamma-ray bursts (GRBs), gravitational-wave (GW) compact binary mergers, and high-energy neutrinos. GCN distributes alerts between space- and ground-based observatories, physics experiments, and thousands of astronomers around the world.
+The General Coordinates Network is the modern evolution of the [Gamma-ray Coordinates Network](https://gcn.gsfc.nasa.gov) (now referred to as GCN Classic, and formerly known as BACODINE/TAN), updated to use modern, open-source, reliable, and secure alert distribution technologies that have been established by the broader astronomy community.
 
-# Documentation
+GCN has two kinds of data products:
+
+- [**Notices**](/notices) are automated, machine-to-machine, generally real-time, notifications of detections and localizations of astronomical transients detected by space- and ground-based observatories.
+- [**Circulars**](/circulars) are human-readable, citable, rapid but generally not real-time, bulletins observations, quantitative near-term predictions, requests for follow-up observations, or future observing plans.
 
 ## Client Configuration
 

--- a/app/routes/index.mdx
+++ b/app/routes/index.mdx
@@ -3,8 +3,10 @@ meta:
   title: GCN - General Coordinates Network
 ---
 
+import { Link } from '@remix-run/react'
 import {
   Card,
+  CardBody,
   CardFooter,
   CardGroup,
   CardHeader,
@@ -16,27 +18,33 @@ import {
   IconSecurity,
 } from '@trussworks/react-uswds'
 
-# Welcome to the General Coordinates Network (GCN)
+<div
+  className="grid-row usa-hero margin-0 padding-0"
+  style={{ backgroundImage: 'none' }}
+>
+  <div className="tablet:grid-col-6 bg-base-darkest padding-4">
+    <h1 className="usa-hero__heading">
+      <span className="usa-hero__heading--alt">The new GCN:</span>{' '}
+      Multimessenger astronomy alerts delivered over Kafka
+    </h1>
+    <p className="text-base-lightest">
+      GCN distributes alerts between space- and ground-based observatories,
+      physics experiments, and thousands of astronomers around the world.
+    </p>
+    <Link to="/TODO" className="usa-button">
+      Start streaming GCN Notices
+    </Link>
+  </div>
+  <img
+    src="https://gcn.gsfc.nasa.gov/GCN.gif"
+    className="tablet:grid-col-6"
+    alt="GCN Diagram"
+  />
+</div>
 
-<img
-  src="https://gcn.gsfc.nasa.gov/GCN.gif"
-  width="400"
-  align="right"
-  alt="GCN Diagram"
-/>
+The General Coordinates Network (GCN) is a public collaboration platform run by NASA for the astronomy research community to share alerts and rapid communications about high-energy, multimessenger, and transient phenomena. For more information, see [What is GCN?](/docs/#what-is-gcn)
 
-The General Coordinates Network (GCN) is a public collaboration platform run by NASA for the astronomy research community to share alerts and rapid communications about high-energy, multimessenger, and transient phenomena. GCN is the established platform for publishing discoveries and follow-up of gamma-ray bursts (GRBs), gravitational-wave (GW) compact binary mergers, and high-energy neutrinos. GCN distributes alerts between space- and ground-based observatories, physics experiments, and thousands of astronomers around the world.
-
-The General Coordinates Network is the modern evolution of the [Gamma-ray Coordinates Network](https://gcn.gsfc.nasa.gov) (now referred to as GCN Classic, and formerly known as BACODINE/TAN), updated to use modern, open-source, reliable, and secure alert distribution technologies that have been established by the broader astronomy community.
-
-## GCN Data Products
-
-- [**Notices**](/notices) are automated, machine-to-machine, generally real-time, notifications of detections and localizations of astronomical transients detected by space- and ground-based observatories.
-- [**Circulars**](/circulars) are human-readable, citable, rapid but generally not real-time, bulletins observations, quantitative near-term predictions, requests for follow-up observations, or future observing plans.
-
-## GCN Data Access Methods
-
-There are three ways to receive GCN Notices programmatically in real time:
+There are three ways to stream GCN Notices in real time:
 
 <CardGroup>
   <Card gridLayout={{ tablet: { col: 4 } }} headerFirst>
@@ -50,8 +58,16 @@ There are three ways to receive GCN Notices programmatically in real time:
         alt="Data flow diagram for GCN Classic"
       />
     </CardMedia>
-    <CardFooter>
+    <CardBody>
       <p>Three formats, three protocols.</p>
+    </CardBody>
+    <CardFooter>
+      <a
+        className="usa-button usa-button--base"
+        href="https://gcn.gsfc.nasa.gov/invitation.html"
+      >
+        <>Get Started (Old Web Site)</>
+      </a>
     </CardFooter>
   </Card>
   <Card
@@ -69,8 +85,13 @@ There are three ways to receive GCN Notices programmatically in real time:
         alt="Data flow diagram for GCN Classic over Kafka"
       />
     </CardMedia>
-    <CardFooter>
+    <CardBody>
       <p>Three formats, one protocol.</p>
+    </CardBody>
+    <CardFooter>
+      <Link className="usa-button" to="/TODO">
+        Get Started
+      </Link>
     </CardFooter>
   </Card>
   <Card gridLayout={{ tablet: { col: 4 } }} headerFirst>
@@ -84,9 +105,9 @@ There are three ways to receive GCN Notices programmatically in real time:
         alt="Data flow diagram for GCN Kafka"
       />
     </CardMedia>
-    <CardFooter>
+    <CardBody>
       <p>One format, one protocol.</p>
-    </CardFooter>
+    </CardBody>
   </Card>
 </CardGroup>
 

--- a/theme/custom.scss
+++ b/theme/custom.scss
@@ -146,7 +146,7 @@ a[rel~='external'] {
     @include u-bg('accent-cool');
   }
 
-  & .usa-card__footer {
+  & .usa-card__body {
     @include u-bg('white');
   }
 }


### PR DESCRIPTION
Place the getting started link front and center on the lading page, and move most of the text to the "What is GCN?" section in the docs.

Note: we need the "Getting started" UI implemented before this is merged.

## Before
![Screen Shot 2022-06-22 at 14 49 07](https://user-images.githubusercontent.com/728407/175113965-d42b4ffe-c94d-42f3-8278-005d69c43dd6.png)

## After
![Screen Shot 2022-06-22 at 14 48 29](https://user-images.githubusercontent.com/728407/175114010-1cfbea9c-0a45-4216-b055-98215803e97e.png)

