### PR TITLE
Exclude notice type category from form submission

### DIFF
--- a/app/components/NoticeTypeCheckboxes.tsx
+++ b/app/components/NoticeTypeCheckboxes.tsx
@@ -166,7 +166,7 @@ export function NoticeTypeCheckboxes() {
       }).map(([mission, noticeTypes]) => ({
         id: mission,
         label: mission,
-        name: mission,
+        name: '',
         nodes: noticeTypes.map((noticeType) => ({
           id: noticeType,
           label: noticeType,


### PR DESCRIPTION
Inputs that do not have a name are excluded from the form data.